### PR TITLE
Be more permissive in gem deps

### DIFF
--- a/ruby/kalibera.gemspec
+++ b/ruby/kalibera.gemspec
@@ -16,9 +16,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^test/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "rake", "~> 13.0.3"
-  spec.add_development_dependency "test-unit", "~> 3.4.1"
+  spec.add_development_dependency "rake", "~> 13.0"
+  spec.add_development_dependency "test-unit", "~> 3.4"
 
-  spec.add_dependency "rbzip2", "~> 0.3.0"
-  spec.add_dependency "memoist", "~> 0.16.2"
+  spec.add_dependency "rbzip2", "~> 0.3"
+  spec.add_dependency "memoist", "~> 0.16"
 end


### PR DESCRIPTION
The ~> operator accepts new versions based on the last provided dot
version. So ~> 0.3.0 would allow 0.3.2 but not 0.4.0. This is often
problematic for keeping multiple deps updated as minor updates get
blocked.

A common Ruby idiom is to specify the MAJOR.MINOR in semver's
MAJOR.MINOR.PATCH. It is generally viewed as relatively "safe" to accept
new minor releases as they _should_ be backwards compatible per semver.